### PR TITLE
add support for fastify >= 0.43

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const fp = require('fastify-plugin')
 
 function fastifyErrorPage(fastify, options, next) {
-  fastify.setErrorHandler(function errorHandler(error, reply) {
+  fastify.setErrorHandler(function errorHandler(error, request, reply) {
     if (error && error.isBoom) {
       reply
         .code(error.output.statusCode)
@@ -21,6 +21,6 @@ function fastifyErrorPage(fastify, options, next) {
 }
 
 module.exports = fp(fastifyErrorPage, {
-  fastify: '>=0.39.1',
+  fastify: '>=0.43',
   name: 'fastify-boom'
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,16 +160,6 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "avvio": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-4.0.1.tgz",
-      "integrity": "sha512-Vaga4uQkddyK3OQydLmOb4FubSxsZ7rmXX+n+JwBNEriidXNixAPVEClHEQp70xXSoY/JOLlGDM3gtRkvTcc6A==",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0",
-        "fastq": "1.5.0"
-      }
-    },
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
@@ -1245,15 +1235,6 @@
       "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "dev": true
     },
-    "fast-iterator": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/fast-iterator/-/fast-iterator-0.2.2.tgz",
-      "integrity": "sha512-tvdb3Xb6SdbKxjYdnIgmIdumC+MZ1DE0I4tRlWRyr9flr173borgU6pb6jRdlRoXkMAXUjFqMAEeWkG6j0yG7g==",
-      "dev": true,
-      "requires": {
-        "reusify": "1.0.3"
-      }
-    },
     "fast-json-parse": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
@@ -1265,29 +1246,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
-    },
-    "fast-json-stringify": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-0.17.0.tgz",
-      "integrity": "sha512-u6d857jtxcTTm00UIFDO6jCB3R/c0AzH89AxU3rI1twmkVPAHo/riUGH20UaDOMem9YXwcKrnoX6pF2dG3xlHA==",
-      "dev": true,
-      "requires": {
-        "ajv": "6.0.1",
-        "fast-safe-stringify": "1.2.3"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.0.1.tgz",
-          "integrity": "sha1-KJhYCp8971+chd/q16IiPvE889o=",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        }
-      }
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1302,43 +1260,66 @@
       "dev": true
     },
     "fastify": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-0.39.1.tgz",
-      "integrity": "sha512-bOf1MPzXWLZpwS3l9vJQzW8G/PdMljRTKJsAMg3ykudknkQ0HXFI+h+L9g4XCjlLsqGNvFXBZ2VwXkYF/SsOgg==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-0.43.0.tgz",
+      "integrity": "sha512-jlVWFTOaeIwDs48GE6t0XmWJuCGPtF/OG/QsygzbRZOeVZKjzMw5SYTPouRBgcodXIAFt1vKZ0Iq7oF8/jwC1Q==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.9",
         "@types/pino": "4.7.1",
         "abstract-logging": "1.0.0",
-        "ajv": "6.0.1",
-        "avvio": "4.0.1",
-        "fast-iterator": "0.2.2",
-        "fast-json-stringify": "0.17.0",
-        "find-my-way": "1.9.0",
+        "ajv": "6.2.0",
+        "avvio": "5.4.1",
+        "end-of-stream": "1.4.1",
+        "fast-json-stringify": "1.2.0",
+        "find-my-way": "1.10.1",
         "flatstr": "1.0.5",
         "light-my-request": "2.0.1",
         "middie": "3.1.0",
-        "pino": "4.10.3",
-        "pump": "2.0.0"
+        "pino": "4.10.3"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.0.1.tgz",
-          "integrity": "sha1-KJhYCp8971+chd/q16IiPvE889o=",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.0.tgz",
+          "integrity": "sha1-r6wpW7qgFSRJ5SJ0LkVHwa6TKNI=",
           "dev": true,
           "requires": {
             "fast-deep-equal": "1.0.0",
             "fast-json-stable-stringify": "2.0.0",
             "json-schema-traverse": "0.3.1"
           }
+        },
+        "avvio": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/avvio/-/avvio-5.4.1.tgz",
+          "integrity": "sha512-pL6ePQvU+zraPWK8Lz1TInoAm4WMzxZBKPw8WlnAxu8iFRoFUg+B6KkElCt8YesE7ASiFmkVOwMcEsy7qwYbJw==",
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0",
+            "fastq": "1.5.0"
+          }
+        },
+        "fast-json-stringify": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.2.0.tgz",
+          "integrity": "sha512-l8Qp5GQabCk+mPPJLRlot0Qsc54TerLEbXG00vIWrH4ewd8o7/8Hj7aUCsTMfupgiURDpRlZzrztfGCBacjixw==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.2.0"
+          }
+        },
+        "find-my-way": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-1.10.1.tgz",
+          "integrity": "sha512-N3SCui48+ZDvRT6cuarjrhaWP2H2zBXzMENu00G+gLqG0e9rgj2WM2tiVkVU2mRUyZzHZ/9CbzIncFziNLWCGQ==",
+          "dev": true
         }
       }
     },
     "fastify-plugin": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-0.2.1.tgz",
-      "integrity": "sha512-lBEMzhWRwEH30Pu1MJG+4s5LVF3jCCRArBOeabj/OQKVZYx7rG9HEbXh+y0aS3L/NkIwqlvKXtYik/e8lowdjA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-0.2.2.tgz",
+      "integrity": "sha512-oRJdjdudgCkQQUARNeh2rkbxFAmj2OhCJSVBNBLUbhS0orF+IMQ4u/bc661N1jh/wDI2J+YKmXmmHSVFQI4e7A==",
       "requires": {
         "semver": "5.5.0"
       }
@@ -1370,12 +1351,6 @@
         "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
       }
-    },
-    "find-my-way": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-1.9.0.tgz",
-      "integrity": "sha512-QfFoUnIO29oYx0rxbRZvtbnbPxL6bkSbQYq3eyXz5d1MpBSI69H8+B056ExMY+v6iP4lox+ndEAERs4QSe0VPQ==",
-      "dev": true
     },
     "find-up": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
   },
   "homepage": "https://github.com/jeromemacias/fastify-boom#readme",
   "dependencies": {
-    "fastify-plugin": "^0.2.1",
+    "fastify-plugin": "^0.2.2",
     "boom": "^7.1.1"
   },
   "devDependencies": {
     "eslint": "^4.14.0",
     "eslint-config-hemera": "0.0.2",
-    "fastify": "^0.39.1",
+    "fastify": "^0.43.0",
     "np": "^2.18.3",
     "pre-commit": "~1.2.2",
     "prettier": "^1.10.2",


### PR DESCRIPTION
There are a couple of breaking changes in fastify after 0.43, in the particular case of this plugin is an extra param in the ``setErrorHandler``; this PR should fix that

closes #1 